### PR TITLE
avoid unnecessary default dir=auto to all nodes; support <ul> and <ol>

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,9 @@ const TextDirection = Extension.create({
     name: 'textDirection',
     addOptions() {
         return {
-            types: ['heading', 'paragraph'],
+            types: ['heading', 'paragraph', 'orderedList', 'bulletList'],
             directions: ['ltr', 'rtl', 'auto'],
-            defaultDirection: 'auto',
+            defaultDirection: null,
         }
     },
     addGlobalAttributes() {


### PR DESCRIPTION
when defaultDirection is 'auto', it will add "dir='auto'" to all html elements, which is redundant and undesirable. 